### PR TITLE
Hohes Gebäude "Arne" entfernt

### DIFF
--- a/hohe_gebaeude_von_freifunkern.geojson
+++ b/hohe_gebaeude_von_freifunkern.geojson
@@ -80,22 +80,6 @@
           53.0713558719098
         ]
       }
-    },
-    {
-      "type": "Feature",
-      "properties": {
-        "marker-color": "#7e7e7e",
-        "marker-size": "medium",
-        "marker-symbol": "",
-        "name": "ahne"
-      },
-      "geometry": {
-        "type": "Point",
-        "coordinates": [
-          8.80027949810028,
-          53.09558316142322
-        ]
-      }
     }
   ]
 }


### PR DESCRIPTION
Auf dem Dach hängt jetzt eine Nanostation. Somit ist der Standort im Meshviewer und der Eintrag hier nicht mehr nötig.
